### PR TITLE
Restartable source emitter composable redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
-# poly-synth branch
-This branch is made in order to polish the abstract classes and interfaces design for a 'poly synth', which is basically a polyphonic synthesizer wich uses many internal mono synthesizers.
-
-The code corresponding to this branch is in the `src/audio/core/synth.ts` file and contains two main classes/interfaces:
-- **abstract class SynthVoice<N extends Note>**: this represents a single voice
-- **abstract class PolySynth<N extends Note, V extends SynthVoice< N >>**: this represents a polyphonic synthesizer that internally uses multiple **SynthVoice<N extends Note>** instances; it contains all the logic that implements the polyphonic behaviour
-
-
-These abstract classes and interfaces will then be used by all synthesizers in the this project.
+# restartable-source-emitter-composable-redesign branch
+This branch is made in order to improve the design of composable 'source emitters'. A 'source emitter' is a node that is the first source of a signal. In this context, a 'source emitter' is also always restartable. 
 
 # React + TypeScript + Vite
 

--- a/src/audio/core/emitter.ts
+++ b/src/audio/core/emitter.ts
@@ -19,21 +19,33 @@ export abstract class RestartableSourceGenerator implements Emitter
     // Inherited from 'Emitter' interface
     public abstract getOutputNode(): AudioNode;
 
-    protected abstract getEndableNodes(): Array<EndableNode>;
     /* This method must recreate the array of endable nodes, every time a new note is played */
     protected abstract setEndableNodes(): void;
     
+    /* Must instantiate and connect all internal nodes, except for the node returned by 'getOutputNode()' */
     protected abstract initNodes(): void;
+
+    /* Must return the internal source nodes which have the 'onended' event (e.g. 'endable nodes') */
+    protected abstract getEndableNodes(): Array<EndableNode>;
+
+    /* Must start all internal source nodes (e.g. the nodes that have a 'start()' method) */
     protected abstract startNodes(): void;
+
+    /* Must stop all internal source nodes (e.g. the same nodes as above ) */
     protected abstract stopNodes(): void;
+
+    /* Must disconnect all internal nodes */
     protected abstract disconnectNodes(): void;
 
+    /* Reinstantiates and connects all internal nodes, , except for the node returned by 'getOutputNode()'.
+    ** It also creates an array of nodes which have the 'onended' event. */
     public recreateSource(): void
     {
         this.initNodes();
         this.setEndableNodes();
     }
 
+    // Starts the fresly created and connencted nodes obtained with 'recreateSource()'
     public startSource(): void
     {
         this.startNodes();
@@ -79,8 +91,13 @@ export abstract class RestartableSourceGenerator implements Emitter
 
 export interface ComposableGenerator
 {
+    // Must re-instantiate and connect all internal nodes, but must NOT start them
     recreateInternalNodes(): void;
+
+    // Must start the internal nodes
     startSignal(): void;
+
+    // Must stop the internal nodes
     stopSignal(): void;
 }
 

--- a/src/audio/synth/virtual-analog/test-synth.ts
+++ b/src/audio/synth/virtual-analog/test-synth.ts
@@ -54,9 +54,10 @@ export class TestMonoSynth extends SynthVoice<Note12TET>
 
         // const currentTime = this.audioContext.currentTime;
         // this.outputNode.gain.setTargetAtTime(Settings.maxOscGain, currentTime, 2); // example 500 milisec release time
+        
+        this.oscillator.recreateSource();
+        this.oscillator.setFrequency(oscFreq);
         this.oscillator.startSource();
-
-        this.oscillator.setFrequency(oscFreq); // maybe should just set octaves and semitones?
     }
 
     // Method inheritted from 'MonoSynth<>' abstract class


### PR DESCRIPTION
This branch is made in order to improve the design of composable 'source emitters'. A 'source emitter' is a node that is the first source of a signal. In this context, a 'source emitter' is also always restartable. 